### PR TITLE
Changed version to 1.4.1 which fixes the gitlab rbac issue

### DIFF
--- a/lab-prep/rhdh-operator.yaml
+++ b/lab-prep/rhdh-operator.yaml
@@ -12,11 +12,11 @@ metadata:
   namespace: rhdh-operator
 spec:
   channel: fast
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: rhdh
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: rhdh-operator.v1.4.0
+  startingCSV: rhdh-operator.v1.4.1
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup


### PR DESCRIPTION
RHDH 1.4.1 fixes the gitlab RBAC issue when loading the org. Set to operator to manual update strategy to avoid automatic updates - Note: when installing the operator you need to approve the update plan once. 